### PR TITLE
Fix Import-Module Path not found bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ scoop install scoop-completion
 Enable completion in current shell:
 ```powershell
 # enable completion in current shell, use absolute path because PowerShell Core not respect $env:PSModulePath
-Import-Module "$($(Get-Item $(Get-Command scoop).Path).Directory.Parent.FullName)\modules\scoop-completion"
+Import-Module "$($(Get-Item $(Get-Command scoop.ps1).Path).Directory.Parent.FullName)\modules\scoop-completion"
 ```
 
 Auto-load, please modify $Profile manually. If you want completion to work for allusers | allhosts, read [Docs](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_profiles?view=powershell-6#the-profile-variable)

--- a/README.zh.md
+++ b/README.zh.md
@@ -20,7 +20,7 @@ scoop install scoop-completion
 在当前 shell 启用补全:
 ```powershell
 # enable completion in current shell
-Import-Module "$($(Get-Item $(Get-Command scoop).Path).Directory.Parent.FullName)\modules\scoop-completion"
+Import-Module "$($(Get-Item $(Get-Command scoop.ps1).Path).Directory.Parent.FullName)\modules\scoop-completion"
 ```
 
 自动加载，请手动修改 $Profile。如果希望补全为 所有用户 | 所有host 工作，请阅读 [Docs](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_profiles?view=powershell-6#the-profile-variable)


### PR DESCRIPTION
```powershell
PS C:\Users\me> Import-Module "$($(Get-Item $(Get-Command scoop).Path).Directory.Parent.FullName)\modules\scoop-completion"
Get-Item: Cannot bind argument to parameter 'Path' because it is null.
Import-Module: The specified module '\modules\scoop-completion' was not loaded because no valid module file was found in any module directory.
```

bug: `(Get-Command scoop).Path` is null. System Info:

```powershell
PS C:\Users\me> $PSVersionTable

Name                           Value
----                           -----
PSVersion                      7.1.4
PSEdition                      Core
GitCommitId                    7.1.4
OS                             Microsoft Windows 10.0.22000
Platform                       Win32NT
PSCompatibleVersions           {1.0, 2.0, 3.0, 4.0…}
PSRemotingProtocolVersion      2.3
SerializationVersion           1.1.0.1
WSManStackVersion              3.0

PS C:\Users\me> scoop --version
Current Scoop version:
09200504 (HEAD -> master, origin/master, origin/HEAD) reset: skip when app instance is running (#4359)
```