### PR TITLE
Remove Import-Module workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,7 @@ scoop install scoop-completion
 
 Enable completion in current shell:
 ```powershell
-# enable completion in current shell, use absolute path because PowerShell Core not respect $env:PSModulePath
-Import-Module "$($(Get-Item $(Get-Command scoop.ps1).Path).Directory.Parent.FullName)\modules\scoop-completion"
+Import-Module scoop-completion
 ```
 
 Auto-load, please modify $Profile manually. If you want completion to work for allusers | allhosts, read [Docs](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_profiles?view=powershell-6#the-profile-variable)

--- a/README.zh.md
+++ b/README.zh.md
@@ -20,7 +20,7 @@ scoop install scoop-completion
 在当前 shell 启用补全:
 ```powershell
 # enable completion in current shell
-Import-Module "$($(Get-Item $(Get-Command scoop.ps1).Path).Directory.Parent.FullName)\modules\scoop-completion"
+Import-Module scoop-completion
 ```
 
 自动加载，请手动修改 $Profile。如果希望补全为 所有用户 | 所有host 工作，请阅读 [Docs](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_profiles?view=powershell-6#the-profile-variable)


### PR DESCRIPTION
As of https://github.com/PowerShell/PowerShell/pull/11057, you don't need the full path workaround.